### PR TITLE
Fix 'use strict' typo

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -1,5 +1,5 @@
 module.exports.and = function (a, b, cbA, cbB) {
-    'us strict';
+    'use strict';
     var ret = Math.min(a, b);
     if (ret === a) {
         cbA(ret);


### PR DESCRIPTION
There was a typo on 'us strict'
